### PR TITLE
Fix typo in 'Extended Capabilities' field name

### DIFF
--- a/argo.py
+++ b/argo.py
@@ -244,7 +244,7 @@ if __name__ == "__main__":
                             quadruplets[i][0] = process_input_string(packet_dict[entry]['info'])
                         except Exception as e:
                             pass
-                    elif packet_dict[entry]['ID'] == 'Extendend Capabilities':
+                    elif packet_dict[entry]['ID'] == 'Extended Capabilities':
                         try:
                             quadruplets[i][1] = process_input_string(packet_dict[entry]['info'])
                         except Exception as e:


### PR DESCRIPTION
Hi!
I noticed a small typo in argo.py at line 245: 'Extendend Capabilities' should be 'Extended Capabilities'. This was preventing the parser from recognizing the Extended Capabilities field properly. Just thought I’d send a quick fix  thanks again for the great work!